### PR TITLE
fix: Path ends nodes selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ import {clusterPaths, convertPolygonsToGraph, getClusteredPathFromGraph, Shape} 
 ```typescript
 function getClusteredPath (
     paths: FeatureCollection<LineString>,
-    startPosition: Position,
-    endPosition: Position,
     clusteringSettings: Partial<ClusteringSettings> = {}
 ): Feature<LineString>
 ```
@@ -70,7 +68,7 @@ function clusterPaths( paths: Feature<LineString>[], granularity: number, shape?
 function convertPolygonsToGraph( cells: FeatureCollection<Polygon, {weight: number}> ): Graph;
 
 // 3. Extract average path from graph
-function getClusteredPathFromGraph( graph: Graph, start: Position, end: Position ): Feature<LineString>;
+function getClusteredPathFromGraph( graph: Graph, start: string, end: string ): Feature<LineString>;
 ```
 
 ### Discretization shape

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@indoor-analytics/discrete-clustering",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indoor-analytics/discrete-clustering",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Clusters a bunch of paths by space discretization.",
   "author": "Rémy Raes",
   "repository": "https://github.com/indoor-analytics/discrete-clustering",

--- a/src/graph/getClusteredPathFromGraph.ts
+++ b/src/graph/getClusteredPathFromGraph.ts
@@ -1,7 +1,6 @@
 import {Feature, lineString, LineString, Position} from "@turf/helpers";
 import Graph from "graphology";
 import dijkstra from 'graphology-shortest-path/dijkstra';
-import distance from "@turf/distance";
 
 
 function _nodeToPosition(
@@ -16,34 +15,15 @@ function _nodeToPosition(
  * graph; this will try and select edges that feature the biggest weight possible.
  *
  * @param graph weighted-edges graph
- * @param start starting position (may not be a graph's edge)
- * @param end ending position (may not be a graph's edge)
+ * @param startingNode starting position (may not be a graph's edge)
+ * @param endingNode ending position (may not be a graph's edge)
  * @returns
  */
 export function getClusteredPathFromGraph(
     graph: Graph,
-    start: Position,
-    end: Position
+    startingNode: string,
+    endingNode: string
 ): Feature<LineString> {
-    let startingNode = '';
-    let endingNode = '';
-    let startingDistance = Number.MAX_SAFE_INTEGER;
-    let endingDistance = Number.MAX_SAFE_INTEGER;
-
-    // looking for closest nodes to start/end positions
-    graph.forEachNode(node => {
-        const distanceToStart = distance(_nodeToPosition(node), start);
-        if (distanceToStart < startingDistance) {
-            startingNode = node;
-            startingDistance = distanceToStart;
-        }
-
-        const distanceToEnd = distance(_nodeToPosition(node), end);
-        if (distanceToEnd < endingDistance) {
-            endingNode = node;
-            endingDistance = distanceToEnd;
-        }
-    });
 
     // cloning graph and reversing its weights
     const graphClone = new Graph().import(graph.export());

--- a/src/graph/getClusteredPathFromGraph.ts
+++ b/src/graph/getClusteredPathFromGraph.ts
@@ -25,6 +25,11 @@ export function getClusteredPathFromGraph(
     endingNode: string
 ): Feature<LineString> {
 
+    if (!graph.hasNode(startingNode))
+        throw new RangeError(`"${startingNode}" is not a graph node.`);
+    else if (!graph.hasNode(endingNode))
+        throw new RangeError(`"${endingNode}" is not a graph node.`);
+
     // cloning graph and reversing its weights
     const graphClone = new Graph().import(graph.export());
     graphClone.forEachEdge(edge => {

--- a/src/graph/getClusteredPathFromGraph.ts
+++ b/src/graph/getClusteredPathFromGraph.ts
@@ -1,13 +1,7 @@
-import {Feature, lineString, LineString, Position} from "@turf/helpers";
+import {Feature, lineString, LineString} from "@turf/helpers";
 import Graph from "graphology";
 import dijkstra from 'graphology-shortest-path/dijkstra';
-
-
-function _nodeToPosition(
-    node: string
-): Position {
-    return node.split(',').map(c => +c);
-}
+import {nodeToPosition} from "../utils/nodeToPosition";
 
 
 /**
@@ -46,5 +40,5 @@ export function getClusteredPathFromGraph(
     if (!pathNodes)
         throw new RangeError('Path cannot be extracted from graph, try using a smaller granularity.');
 
-    return lineString(pathNodes.map(node => _nodeToPosition(node)));
+    return lineString(pathNodes.map(node => nodeToPosition(node)));
 }

--- a/src/graph/getEdgeNodesFromPaths.ts
+++ b/src/graph/getEdgeNodesFromPaths.ts
@@ -1,19 +1,65 @@
 import Graph from "graphology";
-import {FeatureCollection, LineString} from "@turf/helpers";
+import {featureCollection, FeatureCollection, LineString, point, Position} from "@turf/helpers";
+import distance from "@turf/distance";
+import centroid from "@turf/centroid";
+
+
+function _nodeToPosition(
+    node: string
+): Position {
+    return node.split(',').map(c => +c);
+}
 
 
 /**
  * Extracts graph nodes that are most representative of input paths beginning
  * positions and ending positions.
- * @param _graph
- * @param _paths
+ * @param graph
+ * @param paths
  */
 export function getEdgeNodesFromPaths(
-    _graph: Graph,
-    _paths: FeatureCollection<LineString>
+    graph: Graph,
+    paths: FeatureCollection<LineString>
 ): {
     start: string,
     end: string
 } {
-    throw new Error('not implemented');
+    // compute start and end centroids
+    const startPositions = featureCollection([]);
+    const endPositions = featureCollection([]);
+    paths.features.forEach(path => {
+        startPositions.features.push(
+            point(path.geometry.coordinates[0])
+        );
+        endPositions.features.push(
+            point(path.geometry.coordinates[path.geometry.coordinates.length-1])
+        );
+    });
+    const startCentroid = centroid(startPositions);
+    const endCentroid = centroid(endPositions);
+
+    let startingNode = '';
+    let endingNode = '';
+    let startingDistance = Number.MAX_SAFE_INTEGER;
+    let endingDistance = Number.MAX_SAFE_INTEGER;
+
+    // looking for closest nodes to start/end positions
+    graph.forEachNode(node => {
+        const distanceToStart = distance(_nodeToPosition(node), startCentroid);
+        if (distanceToStart < startingDistance) {
+            startingNode = node;
+            startingDistance = distanceToStart;
+        }
+
+        const distanceToEnd = distance(_nodeToPosition(node), endCentroid);
+        if (distanceToEnd < endingDistance) {
+            endingNode = node;
+            endingDistance = distanceToEnd;
+        }
+    });
+
+    return {
+        start: startingNode,
+        end: endingNode
+    };
 }

--- a/src/graph/getEdgeNodesFromPaths.ts
+++ b/src/graph/getEdgeNodesFromPaths.ts
@@ -1,14 +1,8 @@
 import Graph from "graphology";
-import {featureCollection, FeatureCollection, LineString, point, Position} from "@turf/helpers";
+import {featureCollection, FeatureCollection, LineString, point} from "@turf/helpers";
 import distance from "@turf/distance";
 import centroid from "@turf/centroid";
-
-
-function _nodeToPosition(
-    node: string
-): Position {
-    return node.split(',').map(c => +c);
-}
+import {nodeToPosition} from "../utils/nodeToPosition";
 
 
 /**
@@ -45,13 +39,13 @@ export function getEdgeNodesFromPaths(
 
     // looking for closest nodes to start/end positions
     graph.forEachNode(node => {
-        const distanceToStart = distance(_nodeToPosition(node), startCentroid);
+        const distanceToStart = distance(nodeToPosition(node), startCentroid);
         if (distanceToStart < startingDistance) {
             startingNode = node;
             startingDistance = distanceToStart;
         }
 
-        const distanceToEnd = distance(_nodeToPosition(node), endCentroid);
+        const distanceToEnd = distance(nodeToPosition(node), endCentroid);
         if (distanceToEnd < endingDistance) {
             endingNode = node;
             endingDistance = distanceToEnd;

--- a/src/graph/getEdgeNodesFromPaths.ts
+++ b/src/graph/getEdgeNodesFromPaths.ts
@@ -1,0 +1,20 @@
+import {EdgeEntry} from "graphology-types";
+import Graph from "graphology";
+import {FeatureCollection, LineString} from "@turf/helpers";
+
+
+/**
+ * Extracts graph nodes that are most representative of input paths beginning
+ * positions and ending positions.
+ * @param _graph
+ * @param _paths
+ */
+export function getEdgeNodesFromPaths(
+    _graph: Graph,
+    _paths: FeatureCollection<LineString>
+): {
+    start: EdgeEntry,
+    end: EdgeEntry
+} {
+    throw new Error('not implemented');
+}

--- a/src/graph/getEdgeNodesFromPaths.ts
+++ b/src/graph/getEdgeNodesFromPaths.ts
@@ -1,4 +1,3 @@
-import {EdgeEntry} from "graphology-types";
 import Graph from "graphology";
 import {FeatureCollection, LineString} from "@turf/helpers";
 
@@ -13,8 +12,8 @@ export function getEdgeNodesFromPaths(
     _graph: Graph,
     _paths: FeatureCollection<LineString>
 ): {
-    start: EdgeEntry,
-    end: EdgeEntry
+    start: string,
+    end: string
 } {
     throw new Error('not implemented');
 }

--- a/src/utils/getClusteredPath.ts
+++ b/src/utils/getClusteredPath.ts
@@ -3,6 +3,7 @@ import {Shape} from "./Shape";
 import {clusterSpace} from "../recursive/clusterSpace";
 import {convertPolygonsToGraph} from "../graph/convertPolygonsToGraph";
 import {getClusteredPathFromGraph} from "../graph/getClusteredPathFromGraph";
+import {getEdgeNodesFromPaths} from "../graph/getEdgeNodesFromPaths";
 
 
 interface ClusteringSettings {
@@ -37,5 +38,6 @@ export function getClusteredPath (
     const settings: ClusteringSettings = {...defaultClusteringSettings, ...clusteringSettings};
     const cells = clusterSpace(paths, settings.targetDepth, true, clusteringSettings.shape);
     const graph = convertPolygonsToGraph(cells);
-    return getClusteredPathFromGraph(graph, startPosition, endPosition);
+    const positions = getEdgeNodesFromPaths(graph, paths);
+    return getClusteredPathFromGraph(graph, positions.start, positions.end);
 }

--- a/src/utils/getClusteredPath.ts
+++ b/src/utils/getClusteredPath.ts
@@ -1,4 +1,4 @@
-import {Feature, FeatureCollection, LineString, Position} from "@turf/helpers";
+import {Feature, FeatureCollection, LineString} from "@turf/helpers";
 import {Shape} from "./Shape";
 import {clusterSpace} from "../recursive/clusterSpace";
 import {convertPolygonsToGraph} from "../graph/convertPolygonsToGraph";
@@ -25,14 +25,10 @@ const defaultClusteringSettings: ClusteringSettings = {
  * (this is a convenience method that only calls this package's other methods)
  *
  * @param paths input paths to cluster
- * @param startPosition starting position (may not be a graph edge)
- * @param endPosition ending position (may not be a graph edge)
  * @param clusteringSettings optional settings to customize path generation
  */
 export function getClusteredPath (
     paths: FeatureCollection<LineString>,
-    startPosition: Position,
-    endPosition: Position,
     clusteringSettings: Partial<ClusteringSettings> = {}
 ): Feature<LineString> {
     const settings: ClusteringSettings = {...defaultClusteringSettings, ...clusteringSettings};

--- a/src/utils/nodeToPosition.ts
+++ b/src/utils/nodeToPosition.ts
@@ -1,0 +1,13 @@
+import {Position} from "@turf/helpers";
+
+
+/**
+ * Convenience method that converts a node string ("longitude/latitude")
+ * into a Position ([longitude, latitude]).
+ * @param node string to convert to position
+ */
+export function nodeToPosition(
+    node: string
+): Position {
+    return node.split(',').map(c => +c);
+}

--- a/test/graph/getClusteredPathFromGraph.test.ts
+++ b/test/graph/getClusteredPathFromGraph.test.ts
@@ -5,9 +5,10 @@ import {getEdgeNodesFromPaths} from "../../src/graph/getEdgeNodesFromPaths";
 import {featureCollection} from "@turf/helpers";
 
 describe('getClusteredPathFromGraph', () => {
+    const paths = getPaths();
+
     it ('should return a path for all shapes', () => {
         for (const shape of [Shape.Square, Shape.Hexagon, Shape.Triangle]) {
-            const paths = getPaths();
             const cells = clusterPaths(paths, 60, shape);
             const testGraph = convertPolygonsToGraph(cells);
             const positions = getEdgeNodesFromPaths(testGraph, featureCollection(paths));
@@ -20,5 +21,13 @@ describe('getClusteredPathFromGraph', () => {
 
             expect(path.geometry.coordinates.length).toBeGreaterThan(0);
         }
+    });
+
+    it ('should throw with a non-existing starting node', () => {
+        const cells = clusterPaths(paths, 60, Shape.Triangle);
+        const testGraph = convertPolygonsToGraph(cells);
+        const positions = getEdgeNodesFromPaths(testGraph, featureCollection(paths));
+        const getPath = () => getClusteredPathFromGraph(testGraph, 'hellothere', positions.end);
+        expect(getPath).toThrow(new RangeError('"hellothere" is not a graph edge.'));
     });
 });

--- a/test/graph/getClusteredPathFromGraph.test.ts
+++ b/test/graph/getClusteredPathFromGraph.test.ts
@@ -23,18 +23,16 @@ describe('getClusteredPathFromGraph', () => {
         }
     });
 
+    const cells = clusterPaths(paths, 60, Shape.Triangle);
+    const testGraph = convertPolygonsToGraph(cells);
+    const positions = getEdgeNodesFromPaths(testGraph, featureCollection(paths));
+
     it ('should throw with a non-existing starting node', () => {
-        const cells = clusterPaths(paths, 60, Shape.Triangle);
-        const testGraph = convertPolygonsToGraph(cells);
-        const positions = getEdgeNodesFromPaths(testGraph, featureCollection(paths));
         const getPath = () => getClusteredPathFromGraph(testGraph, 'hellothere', positions.end);
         expect(getPath).toThrow(new RangeError('"hellothere" is not a graph node.'));
     });
 
     it ('should throw with a non-existing ending node', () => {
-        const cells = clusterPaths(paths, 60, Shape.Triangle);
-        const testGraph = convertPolygonsToGraph(cells);
-        const positions = getEdgeNodesFromPaths(testGraph, featureCollection(paths));
         const getPath = () => getClusteredPathFromGraph(testGraph, '56.254875963,3.14421442', positions.end);
         expect(getPath).toThrow(new RangeError('"56.254875963,3.14421442" is not a graph node.'));
     });

--- a/test/graph/getClusteredPathFromGraph.test.ts
+++ b/test/graph/getClusteredPathFromGraph.test.ts
@@ -1,19 +1,21 @@
 import {clusterPaths, convertPolygonsToGraph, Shape} from "../../src";
-import {getPaths, getReferencePath} from "../features/paths";
+import {getPaths} from "../features/paths";
 import {getClusteredPathFromGraph} from "../../src";
+import {getEdgeNodesFromPaths} from "../../src/graph/getEdgeNodesFromPaths";
+import {featureCollection} from "@turf/helpers";
 
 describe('getClusteredPathFromGraph', () => {
-    const referencePath = getReferencePath();
-
     it ('should return a path for all shapes', () => {
         for (const shape of [Shape.Square, Shape.Hexagon, Shape.Triangle]) {
-            const cells = clusterPaths(getPaths(), 60, shape);
+            const paths = getPaths();
+            const cells = clusterPaths(paths, 60, shape);
             const testGraph = convertPolygonsToGraph(cells);
+            const positions = getEdgeNodesFromPaths(testGraph, featureCollection(paths));
 
             const path = getClusteredPathFromGraph(
                 testGraph,
-                referencePath.geometry.coordinates[0],
-                referencePath.geometry.coordinates[referencePath.geometry.coordinates.length-1]
+                positions.start,
+                positions.end
             );
 
             expect(path.geometry.coordinates.length).toBeGreaterThan(0);

--- a/test/graph/getClusteredPathFromGraph.test.ts
+++ b/test/graph/getClusteredPathFromGraph.test.ts
@@ -30,4 +30,12 @@ describe('getClusteredPathFromGraph', () => {
         const getPath = () => getClusteredPathFromGraph(testGraph, 'hellothere', positions.end);
         expect(getPath).toThrow(new RangeError('"hellothere" is not a graph edge.'));
     });
+
+    it ('should throw with a non-existing ending node', () => {
+        const cells = clusterPaths(paths, 60, Shape.Triangle);
+        const testGraph = convertPolygonsToGraph(cells);
+        const positions = getEdgeNodesFromPaths(testGraph, featureCollection(paths));
+        const getPath = () => getClusteredPathFromGraph(testGraph, '56.254875963,3.14421442', positions.end);
+        expect(getPath).toThrow(new RangeError('"56.254875963,3.14421442" is not a graph edge.'));
+    });
 });

--- a/test/graph/getClusteredPathFromGraph.test.ts
+++ b/test/graph/getClusteredPathFromGraph.test.ts
@@ -28,7 +28,7 @@ describe('getClusteredPathFromGraph', () => {
         const testGraph = convertPolygonsToGraph(cells);
         const positions = getEdgeNodesFromPaths(testGraph, featureCollection(paths));
         const getPath = () => getClusteredPathFromGraph(testGraph, 'hellothere', positions.end);
-        expect(getPath).toThrow(new RangeError('"hellothere" is not a graph edge.'));
+        expect(getPath).toThrow(new RangeError('"hellothere" is not a graph node.'));
     });
 
     it ('should throw with a non-existing ending node', () => {
@@ -36,6 +36,6 @@ describe('getClusteredPathFromGraph', () => {
         const testGraph = convertPolygonsToGraph(cells);
         const positions = getEdgeNodesFromPaths(testGraph, featureCollection(paths));
         const getPath = () => getClusteredPathFromGraph(testGraph, '56.254875963,3.14421442', positions.end);
-        expect(getPath).toThrow(new RangeError('"56.254875963,3.14421442" is not a graph edge.'));
+        expect(getPath).toThrow(new RangeError('"56.254875963,3.14421442" is not a graph node.'));
     });
 });

--- a/test/graph/getEdgeNodesFromPaths.test.ts
+++ b/test/graph/getEdgeNodesFromPaths.test.ts
@@ -1,0 +1,16 @@
+import {getEdgeNodesFromPaths} from "../../src/graph/getEdgeNodesFromPaths";
+import {getPaths} from "../features/paths";
+import {clusterPaths, convertPolygonsToGraph, Shape} from "../../src";
+import {featureCollection} from "@turf/helpers";
+
+describe('getEdgeNodesFromPaths', () => {
+    const paths = getPaths();
+    const cells = clusterPaths(getPaths(), 60, Shape.Hexagon);
+    const testGraph = convertPolygonsToGraph(cells);
+
+    it ('should return a starting and an ending position', () => {
+        const positions = getEdgeNodesFromPaths(testGraph, featureCollection(paths));
+        expect(positions.start.length).toBeGreaterThan(0);
+        expect(positions.end.length).toBeGreaterThan(0);
+    });
+});

--- a/test/utils/getClusteredPath.test.ts
+++ b/test/utils/getClusteredPath.test.ts
@@ -1,37 +1,34 @@
-import {featureCollection, Position} from "@turf/helpers";
-import {getPaths, getReferencePath} from "../features/paths";
+import {featureCollection} from "@turf/helpers";
+import {getPaths} from "../features/paths";
 import {getClusteredPath} from "../../src/utils/getClusteredPath";
 import {Shape} from "../../src";
 
 describe('getClusteredPath', () => {
     const paths = featureCollection(getPaths());
-    const referencePath = getReferencePath();
-    const startPos: Position = referencePath.geometry.coordinates[0];
-    const endPos: Position = referencePath.geometry.coordinates[referencePath.geometry.coordinates.length-1];
 
     it ('should return a path with square shape', () => {
-        const path = getClusteredPath(paths, startPos, endPos, {targetDepth: 5, shape: Shape.Square});
+        const path = getClusteredPath(paths, {targetDepth: 5, shape: Shape.Square});
         expect(path.geometry.coordinates.length).not.toEqual(0);
     });
 
     it ('should return a path with triangle shape', () => {
-        const path = getClusteredPath(paths, startPos, endPos, {shape: Shape.Triangle});
+        const path = getClusteredPath(paths, {shape: Shape.Triangle});
         expect(path.geometry.coordinates.length).not.toEqual(0);
     });
 
     it ('should return a path with fit shape', () => {
-        const path = getClusteredPath(paths, startPos, endPos, {shape: Shape.Fit});
+        const path = getClusteredPath(paths, {shape: Shape.Fit});
         expect(path.geometry.coordinates.length).not.toEqual(0);
     });
 
     it ('should throw with hexagon shape', () => {
-        const getPath = () => getClusteredPath(paths, startPos, endPos, {shape: Shape.Hexagon});
+        const getPath = () => getClusteredPath(paths, {shape: Shape.Hexagon});
         expect(getPath).toThrow(new Error('This shape is not supported by this method.'));
     });
 
     it ('should produce more positions with increased depth', () => {
-        const path1 = getClusteredPath(paths, startPos, endPos, {targetDepth: 5});
-        const path2 = getClusteredPath(paths, startPos, endPos, {targetDepth: 6});
+        const path1 = getClusteredPath(paths, {targetDepth: 5});
+        const path2 = getClusteredPath(paths, {targetDepth: 6});
         expect(path1.geometry.coordinates.length).toBeLessThan(path2.geometry.coordinates.length)
     });
 });


### PR DESCRIPTION
Instead of using first and last reference path positions as starting/ending positions for computing most representative path, we now search for and use graph nodes that are closest to respectively input paths' first positions centroid and input paths' last positions centroid.